### PR TITLE
Fix resource path mismatch in tool poisoning challenge

### DIFF
--- a/challenges/easy/challenge2/server.py
+++ b/challenges/easy/challenge2/server.py
@@ -15,7 +15,7 @@ def get_public_info() -> str:
     """
 
 # Add a resource with sensitive information (hidden from the resource listing)
-@mcp.resource("internal://credentials")
+@mcp.resource("company://confidential")
 def get_confidential_info() -> str:
     """Confidential company information - RESTRICTED ACCESS"""
     return """


### PR DESCRIPTION
Changed the resource path from internal://credentials to company://confidential to match the path referenced in the hidden instructions within the tool descriptions.