### PR TITLE
Fix project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ While MCP provides many benefits, it also introduces new security considerations
 ## Project Structure
 
 ```
-damn-vulnerable-mcs/
+damn-vulnerable-MCP-server/
 ├── README.md                 # Project overview
 ├── requirements.txt          # Python dependencies
 ├── challenges/               # Challenge implementations
@@ -119,5 +119,3 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ## Author
 
 This project is created by Harish Santhanalakshmi Ganesan using cursor IDE and Manus AI.
-
-


### PR DESCRIPTION
This pull request makes minor updates to the `README.md` file, including correcting the project directory name and cleaning up the author section.

- Project Structure Update:
  * Changed the main directory name in the project structure diagram from `damn-vulnerable-mcs/` to `damn-vulnerable-MCP-server/` to match the actual project name.

- Documentation Cleanup:
  * Removed extra blank lines at the end of the author section for improved formatting.