### PR TITLE
Fix repo name in setup guide

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,8 +13,8 @@ This guide provides instructions for setting up and running the Damn Vulnerable 
 
 1. Clone the repository:
    ```
-   git clone https://github.com/yourusername/damn-vulnerable-mcs.git
-   cd damn-vulnerable-mcs
+   git clone https://github.com/harishsg993010/damn-vulnerable-MCP-server.git
+   cd damn-vulnerable-MCP-server
    ```
 
 2. Install the required dependencies:


### PR DESCRIPTION
This pull request updates the setup documentation to reflect the correct repository URL and directory name for cloning the project.

- Updated the `docs/setup.md` instructions to use the correct GitHub repository URL and directory name for cloning (`damn-vulnerable-MCP-server` instead of `damn-vulnerable-mcs`).